### PR TITLE
Add "RegressError" to the "regress" module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,9 +63,10 @@ impl MatchPy {
 
 #[pymodule]
 #[pyo3(name = "regress")]
-fn regress_py(_py: Python, m: &PyModule) -> PyResult<()> {
+fn regress_py(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<MatchPy>()?;
     m.add_class::<RegexPy>()?;
+    m.add("RegressError", py.get_type::<RegressError>())?;
     Ok(())
 }
 

--- a/tests/test_regress.py
+++ b/tests/test_regress.py
@@ -49,3 +49,12 @@ def test_named_group():
     assert group
 
     assert text[group] == "fox"
+
+
+def test_error_handling():
+    try:
+        regress.Regex(r"(")
+    except regress.RegressError:
+        pass
+    else:
+        assert False, "error not reached"


### PR DESCRIPTION
By exposing the exception as a module attribute, we ensure that callers can use that name in `except` clauses.

Without this addition, `regress.RegressError` can still be raised, but it has a type which can't be referred to by name.

pyo3 docs use `PyModule.add(...)` in a formulation similar to, but slightly different from, `add_class` usage.

---

I noticed this when trying to setup `regress` to replace the `"format": "regex"`` checker in `check-jsonschema`. I'll be fine using `except Exception` for now, but it would be nice to be able to write the exception handler as `except regress.RegressError`.