### PR TITLE
Update the version of 'regress' to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "regress"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a9ecfa0cb04d0b04dddb99b8ccf4f66bc8dfd23df694b398570bd8ae3a50fb"
+checksum = "4ed9969cad8051328011596bf549629f1b800cf1731e7964b1eef8dfc480d2c2"
 dependencies = [
  "hashbrown",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name = "regress"
 crate-type = ["cdylib"]
 
 [dependencies]
-regress = "0.6.0"
+regress = "0.7.0"
 
 [dependencies.pyo3]
 version = "0.19.2"


### PR DESCRIPTION
I'm not terribly familiar with the toolchain, so let me know if I've made a mistake, but I made an update to `Cargo.toml`. After running the tests, I saw that `Cargo.lock` also had changes. (I think the lockfile gets updated by any build?)

---

I also noticed that the version field in `Cargo.toml` is still at `0.2.3`, so I'm not sure if there's a missing update there?